### PR TITLE
6-1 実務的エラー処理

### DIFF
--- a/src/main/java/jp/co/sample/emp_management/common/GlovalExceptionHandler.java
+++ b/src/main/java/jp/co/sample/emp_management/common/GlovalExceptionHandler.java
@@ -1,0 +1,31 @@
+package jp.co.sample.emp_management.common;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerExceptionResolver;
+import org.springframework.web.servlet.ModelAndView;
+
+/**
+ * 500系のエラーを5xx.htmlへ遷移するクラス.
+ * 
+ * @author nayuta
+ */
+@Component
+public class GlovalExceptionHandler implements HandlerExceptionResolver {
+	// このクラスのログをLOGGERという定数に格納
+	private static final Logger LOGGER = LoggerFactory.getLogger(GlovalExceptionHandler.class);
+
+	@Override
+	public ModelAndView resolveException(HttpServletRequest request, HttpServletResponse response, Object obj,
+			Exception e) {
+		LOGGER.error("システムエラーが発生しました。", e);
+
+		// 自動的に[error/5xx.html]へ遷移
+		return null;
+	}
+
+}

--- a/src/main/java/jp/co/sample/emp_management/controller/AdministratorController.java
+++ b/src/main/java/jp/co/sample/emp_management/controller/AdministratorController.java
@@ -26,6 +26,8 @@ import jp.co.sample.emp_management.service.AdministratorService;
 @Controller
 @RequestMapping("/")
 public class AdministratorController {
+	
+	
 
 	@Autowired
 	private AdministratorService administratorService;

--- a/src/main/resources/templates/error/404.html
+++ b/src/main/resources/templates/error/404.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="ja" xmlns:th="http://www.thymeleaf.org">
+<head>
+<meta charset="UTF-8">
+<title>Insert title here</title>
+</head>
+<body>
+<p>404エラー</p>
+<p>お探しのページは見つかりませんでした。</p>
+
+従業員一覧ページは<a th:href="@{/employee/showList}">こちら</a>
+<br>
+ログイン画面は<a th:href="@{/employee/}">こちら</a>
+
+
+</body>
+</html>

--- a/src/main/resources/templates/error/5xx.html
+++ b/src/main/resources/templates/error/5xx.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="ja" xmlns:th="http://www.thymeleaf.org">
+<head>
+<meta charset="UTF-8">
+<title>Insert title here</title>
+</head>
+<body>
+
+<p>500エラー</p>
+<p>申し訳ございません。ただいまアクセスができません。</p>
+<p>以下のいずれかが原因となります。</p>
+<p>・サーバーエラーが発生</p>
+<p>・アクセス集中によるアクセス不可</p>
+<p>大変申し訳ございませんでした。</p>
+
+従業員一覧ページは<a th:href="@{/employee/showList}">こちら</a>
+<br>
+ログイン画面は<a th:href="@{/employee/}">こちら</a>
+</body>
+</html>


### PR DESCRIPTION
404エラーと500番台のエラーが出た時にエラー画面に遷移するよう、以下の通り改修。

[404エラー]
・templates/errorフォルダを作成
・404.htmlを作成

[500番台エラー]
・common packageを作成
・HandlerExceptionResolverを実装したGlovalExceptionHandler を作成
・5xx.htmlを作成